### PR TITLE
Update vector_fileio.c

### DIFF
--- a/05-file-io-further-details/vector_fileio.c
+++ b/05-file-io-further-details/vector_fileio.c
@@ -96,6 +96,8 @@ ssize_t writev(int fildes, const struct iovec *iov, int iovcnt)
 			return bytes_written;
 		} else {
 			total_bytes_written += bytes_written;
+			if (bytes_written < vec->iov_len)
+				return total_bytes_written;
 		}
 	}
 	return total_bytes_written;
@@ -164,6 +166,8 @@ ssize_t readv(int fildes, const struct iovec *iov, int iovcnt)
 			return bytes_read;
 		} else {
 			total_bytes_read += bytes_read;
+			if (bytes_read < vec->iov_len)
+				return total_bytes_read;
 		}
 	}
 


### PR DESCRIPTION
According to the manpage of readv(2), 

> Buffers are processed in array order.  This  means  that  readv()  completely fills iov[0] before proceeding to iov[1], and so on. 

writev(2) is similar.
